### PR TITLE
Added accounts path for default Django password reset 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 .vscode
+app/sent_emails/*

--- a/app/squac/settings.py
+++ b/app/squac/settings.py
@@ -130,6 +130,11 @@ AUTH_USER_MODEL = 'core.User'
 
 # LOGIN_REDIRECT_URL = "/accounts/"
 
+'''Email backend and filepath allow for storing generated emails
+locally for password reset to test functionality'''
+EMAIL_BACKEND = 'django.core.mail.backends.filebased.EmailBackend'
+EMAIL_FILE_PATH = os.path.join(BASE_DIR, 'sent_emails')
+
 ''' to add quick and dirty email server:
     ADD the following Variables to this file:
     EMAIL_HOST = 'localhost'

--- a/app/squac/urls.py
+++ b/app/squac/urls.py
@@ -18,6 +18,11 @@ from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('accounts/', include('django.contrib.auth.urls')),
     path('api/v1.0/user/', include('user.urls')),
     path('api/v1.0/nslc/', include('nslc.urls'))
 ]
+'''To access password reset: localhost:8000/acounts/password_reset/
+For test reseting password: reset email text file will be created in a
+new directory app/sent_emails/(reset email) and link to password reset
+form will be found in the email text file'''


### PR DESCRIPTION
Also added a file path to store emails for testing password reset. As the password reset is used directly from django with no changes I couldn't think of any new tests to implement with it.